### PR TITLE
fix: dont specify ip in pfcp address

### DIFF
--- a/src/templates/config.yaml.j2
+++ b/src/templates/config.yaml.j2
@@ -1,5 +1,5 @@
 interface_name: [{{ interface_name }}]
-pfcp_address: {{ pfcp_address }}:{{ pfcp_port }}
+pfcp_address: :{{ pfcp_port }}
 metrics_address: :{{ metrics_port }}
 n3_address: {{ n3_address }}
 logging_level: {{ logging_level }}

--- a/tests/unit/expected_config.yaml
+++ b/tests/unit/expected_config.yaml
@@ -1,5 +1,5 @@
 interface_name: [n3]
-pfcp_address: 192.168.250.3:8805
+pfcp_address: :8805
 metrics_address: :9090
 n3_address: 192.168.252.3
 logging_level: debug


### PR DESCRIPTION
# Description

Fixes a bug where the pfcp association would not complete because the service wasn't listening on the right address.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
