### PR TITLE
fix: use cidr notation for n3 and n6 ip addresses

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -81,7 +81,7 @@ config:
       description: Gateway IP address to the Core Network.
     n3-ip:
       type: string
-      default: 192.168.252.3
+      default: 192.168.252.3/24
       description: IP address used by the UPF's Access interface.
     n3-gateway-ip:
       type: string

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -73,7 +73,7 @@ config:
         If set, the eUPF charm will create a Network Attachment Definition (NAD) of type macvlan.
     n6-ip:
       type: string
-      default: 192.168.250.3
+      default: 192.168.250.3/24
       description: IP address used by the UPF's Core interface.
     n6-gateway-ip:
       type: string


### PR DESCRIPTION
# Description

use cidr notation for n3 and n6 ip addresses

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
