### PR TITLE
fix: use dash instead of underscore in config option

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -43,7 +43,7 @@ config:
       default: bridge
       description: |
         Multus CNI plugin to use for the interfaces. Allowed values are `bridge`, `macvlan`, and `host-device`.
-    xdp_attach_mode:
+    xdp-attach-mode:
       type: string
       default: "generic"
       description: |


### PR DESCRIPTION
# Description

Use dash instead of underscore in config option

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
